### PR TITLE
update_sign_in_and_sign_up_css

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -40,7 +40,6 @@ gem 'twilio-ruby', '~> 5.67'
 gem 'simple_form', '~> 5.1'
 gem 'faker', '~> 2.21'
 gem 'validates_timeliness', '~> 6.0.0.beta2'
-gem "font_awesome5_rails", "~> 1.5"
 
 group :development, :test do
   gem 'byebug', platforms: %i[mri mingw x64_mingw]
@@ -48,7 +47,6 @@ group :development, :test do
   gem 'rubocop', '~> 1.28', require: false
   gem 'elasticsearch', '~> 7.0'
   gem 'searchkick', '~> 5.0', '>= 5.0.3'
-  gem 'byebug'
   gem 'rspec', '~> 3.11'
   gem 'rspec-rails'
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -93,7 +93,6 @@ GEM
     dotenv-rails (2.7.6)
       dotenv (= 2.7.6)
       railties (>= 3.2)
-    e2mmap (0.1.0)
     elasticsearch (7.17.1)
       elasticsearch-api (= 7.17.1)
       elasticsearch-transport (= 7.17.1)
@@ -309,8 +308,6 @@ GEM
       activesupport (>= 5.2)
       sprockets (>= 3.0.0)
     thor (1.2.1)
-    thwait (0.2.0)
-      e2mmap
     tilt (2.0.10)
     timeliness (0.4.4)
     turbolinks (5.2.1)
@@ -384,7 +381,6 @@ DEPENDENCIES
   simple_form (~> 5.1)
   sorcery (~> 0.16.1)
   spring
-  thwait (~> 0.2.0)
   turbolinks (~> 5)
   twilio-ruby (~> 5.67)
   tzinfo-data
@@ -398,4 +394,4 @@ RUBY VERSION
    ruby 2.7.5p203
 
 BUNDLED WITH
-   2.3.12
+   2.3.10

--- a/app/views/user_sessions/_form.html.erb
+++ b/app/views/user_sessions/_form.html.erb
@@ -23,7 +23,7 @@
     </div>
 
     <div class="mb-4">
-      <div class="w-11/12 h-11 flex justify-center items-center m-auto bg-green-300 hover:bg-green-400 rounded-lg">
+      <div class="w-11/12 h-11 flex justify-center items-center m-auto bg-white hover:bg-gray-50 border shadow-md rounded-lg cursor-pointer">
         <%= link_to '<img src="https://img.icons8.com/color/48/000000/google-logo.png" class="w-6 mr-2 inline"/> 使用Google登入'.html_safe, auth_at_provider_oauths_path(:provider => :google), class: "w-full text-center" %>
       </div>
     </div>

--- a/app/views/user_sessions/_form.html.erb
+++ b/app/views/user_sessions/_form.html.erb
@@ -1,46 +1,32 @@
 <%# 登入頁面  %>
-<div class="w-11/12 md:w-6/12 lg:w-96 bg-white m-auto mt-36">
-  <div class="mt-10">
+<div class="w-11/12 md:w-6/12 lg:w-96 bg-gray-100 m-auto rounded-2xl shadow-2xl">
+  <div class="mt-36 p-2">
     <%= form_with url: user_sessions_path, method: :post do |f| %>
     <h1 class="text-4xl font-bold py-8 px-5 mt-2">登入</h1>
 
     <div class="mx-4">
-      <%=f.text_field :email, placeholder:"電子郵件", class:"w-full h-11 mb-4 pl-2  border-gray-600 focus:border-green-600 rounded-none border outline-none"%>
-      <%=f.password_field :password, placeholder:"密碼", class:"w-full h-11 pl-2  py-1 px-2 focus:border-green-600 border-gray-600 rounded-none border outline-none"%>
+      <%=f.text_field :email, placeholder:"電子郵件", class:"w-full h-11 mb-4 pl-2  border-gray-600 focus:border-green-600 rounded-none border outline-none rounded-lg"%>
+      <%=f.password_field :password, placeholder:"密碼", class:"w-full h-11 pl-2  py-1 px-2 focus:border-green-600 border-gray-600 rounded-none border outline-none rounded-lg"%>
     </div>
 
-    <div class="mt-5 ">
-      <%= f.submit "登入", class:"w-11/12 h-11 m-auto bg-blue-600 text-white hover:bg-blue-700 block cursor-pointer"%>
+    <div class="mt-5">
+      <%= f.submit "登入", class:"w-11/12 h-11 m-auto bg-blue-600 text-white hover:bg-blue-700 block cursor-pointer rounded-lg"%>
     </div>
 
     <div class="text-right">
-      <%=link_to "忘記密碼？", "#", class: "text-right mr-4 text-sm  text-gray-500   hover:text-gray-900"%>
+      <%=link_to "忘記密碼？", "#", class: "text-right mr-4 text-sm  text-gray-500 hover:text-gray-900"%>
     </div>
 
     <div class="text-center mt-6">
-      <div class="w-full h-px bg-gray-100"></div>
-      <div class=" text-sm  pt-2.5 text-gray-600 bg-whiteinline-block relative -top-5 ">快速登入</div>
+      <div class="w-full h-px bg-gray-200"></div>
+      <div class=" text-sm  pt-2.5 text-gray-600 bg-whiteinline-block relative -top-5">快速登入</div>
     </div>
 
     <div class="mb-4">
-      <div class="w-11/12 h-11 flex justify-center items-center m-auto bg-gray-200 hover:bg-gray-300 ">
+      <div class="w-11/12 h-11 flex justify-center items-center m-auto bg-green-300 hover:bg-green-400 rounded-lg">
         <%= link_to '<img src="https://img.icons8.com/color/48/000000/google-logo.png" class="w-6 mr-2 inline"/> 使用Google登入'.html_safe, auth_at_provider_oauths_path(:provider => :google), class: "w-full text-center" %>
       </div>
     </div>
-
-    <div class="mb-4">
-      <div class="w-11/12 h-11 flex justify-center items-center m-auto bg-black text-white hover:bg-gray-700">
-        <%= link_to '<img src="https://img.icons8.com/color/48/000000/github.png" class="w-6 mr-2 inline"/> 使用Github登入'.html_safe, auth_at_provider_oauths_path(:provider => :github), class: "w-full text-center"%>
-      </div>
-    </div>
-
-    <%#臉書功能還沒做所以點了會失敗  %>
-    <div class="mb-4">
-      <div class="w-11/12 h-11 flex justify-center items-center m-auto bg-blue-800 text-white hover:bg-blue-700">
-        <%= link_to '<img src="https://img.icons8.com/color/48/000000/facebook.png" class="w-6 mr-2 inline"/> 使用Facebook登入'.html_safe, auth_at_provider_oauths_path(:provider => :facebook), class: "w-full text-center"%>
-      </div>
-    </div>
-
 
     <div class="flex justify-center">
       <p class="my-6">第一次使用 Gavel 嗎？ <%=link_to "註冊",new_user_path,class:"text-blue-600 hover:text-gray-900"%></p>

--- a/app/views/users/_form.html.erb
+++ b/app/views/users/_form.html.erb
@@ -11,89 +11,73 @@
     </div>
   <% end %>
 
-  <div class="w-11/12 md:w-6/12 lg:w-96 bg-white m-auto mt-32">
-
+  <div class="w-11/12 md:w-6/12 lg:w-96 bg-gray-50 m-auto rounded-2xl shadow-2xl">
+    <div class="mt-36">
     <% if not current_user %>
-      <div class="mt-5 py-4 text-center bg-gray-50">
+      <div class="py-6 text-center bg-gray-100 rounded-t-xl shadow-sm">
         <p class="text-gray-600">已經有帳戶？<%=link_to "登入", new_user_session_path, class:"font-medium text-blue-600 hover:text-gray-800"%></p>
       </div>
-      <hr class="bg-gray-200">
-
-      <div class="flex justify-between">
-        <h1 class="text-4xl font-bold m-8 text-gray-800">註冊</h1>
-        <span class="text-xs font-medium mt-14 mr-5 text-red-600">* 為必填</span>
-      </div>
-
-    <% else %>
-      <div class="flex justify-between mt-10">
-        <h1 class="text-4xl font-bold m-8 text-gray-800">編輯個人資訊</h1>
-        <span class="text-xs font-medium mt-14 mr-5 text-red-600">* 為必填</span>
-      </div>
-    <% end %>
-      <div class="mb-8 px-6">
-        <div class="bg-gray-100 flex">
-          <span class="m-2 text-red-600">*</span><%= form.label :email, "電子信箱", class:"w-3/12 text-sm font-medium pt-2.5 text-gray-700"%><br>
-          <%= form.text_field :email, placeholder:"請輸入電子郵件", class:"w-9/12 border py-1 px-2 outline-none focus:border-green-500 border-gray-300 text-sm font-normal"%>
+      <hr>
+      <div class="p-2">
+        <div class="flex justify-between">
+          <h1 class="text-4xl font-bold m-8">註冊</h1>
+          <span class="text-xs font-medium mt-14 mr-5 text-red-600">* 為必填</span>
         </div>
-      </div>
 
-      <div class="mb-8 px-6">
-        <div class="bg-gray-100 flex">
-          <span class="text-red-600 m-2">*</span><%= form.label :username, "使用者名稱", class:"w-3/12 md:w-3/12 pt-2.5 text-gray-700 text-sm font-medium"%><br>
-          <%= form.text_field :username, placeholder:"請設定使用者名稱", class:"w-9/12 md:w-9/12 border py-1 px-2 outline-none focus:border-green-500 border-gray-300 text-sm font-normal"%>
+      <% else %>
+        <div class="flex justify-between mt-10">
+          <h1 class="text-4xl font-bold m-8 ">編輯個人資訊</h1>
+          <span class="text-xs font-medium mt-14 mr-5 text-red-600">* 為必填</span>
         </div>
-      </div>
+      <% end %>
+        <div class="mb-6 px-6">
+          <div class="bg-gray-100 flex rounded-lg">
+            <span class="m-2 text-red-600">*</span><%= form.label :email, "電子信箱", class:"w-3/12 text-sm font-medium pt-2.5 text-gray-700"%><br>
+            <%= form.text_field :email, placeholder:"請輸入電子郵件", class:"w-9/12 border py-1 px-2 outline-none focus:border-green-500 border-gray-400 text-sm font-normal rounded-lg"%>
+          </div>
+        </div>
 
-      <% if not current_user %>
-        <div class="mb-8 px-6">
-          <div class="bg-gray-100 flex">
+        <div class="mb-6 px-6">
+          <div class="bg-gray-100 flex rounded-lg">
+            <span class="text-red-600 m-2">*</span><%= form.label :username, "使用者名稱", class:"w-3/12 md:w-3/12 pt-2.5 text-gray-700 text-sm font-medium"%><br>
+            <%= form.text_field :username, placeholder:"請設定使用者名稱", class:"w-9/12 md:w-9/12 border py-1 px-2 outline-none focus:border-green-500 border-gray-400 text-sm font-normal rounded-lg"%>
+          </div>
+        </div>
+
+        <div class="mb-6 px-6">
+          <div class="bg-gray-100 flex rounded-lg">
             <span class="text-red-600 m-2">*</span><%= form.label :password,"密碼", class:"w-3/12 pt-2.5 text-gray-700 text-sm font-medium"%><br>
-            <%= form.password_field :password, placeholder:"請設定6個字元以上的密碼", class:"w-9/12 border py-1 px-2 outline-none focus:border-green-500 border-gray-300 text-sm font-normal"%>
+            <%= form.password_field :password, placeholder:"請設定6個字元以上的密碼", class:"w-9/12 border py-1 px-2 outline-none focus:border-green-500 border-gray-400 text-sm font-normal rounded-lg"%>
           </div>
         </div>
 
-        <div class="mb-8 px-6">
-          <div class="bg-gray-100 flex">
+        <div class="mb-6 px-6">
+          <div class="bg-gray-100 flex rounded-lg">
             <span class="text-red-600 m-2">*</span><%=form.label :password_confirmation, "確認密碼", class:"w-3/12 pt-2.5 text-gray-700 text-sm font-medium"%><br>
-            <%= form.password_field :password_confirmation, placeholder:"請再輸入一次密碼", class:"w-9/12 border py-1 px-2 outline-none focus:border-green-500 border-gray-300 text-sm font-normal"%>
-          </div>
-        </div>
-      <% else %>
-        <div class="mb-8 px-6">
-          <div class="bg-gray-100 flex">
-            <%= form.label :password,"密碼", class:"w-3/12 m-2.5 pl-[0.9em] text-gray-700 text-sm font-medium"%><br>
-            <%= form.password_field :password, placeholder:"若無需修改留空即可", class:"w-9/12 border py-1 px-2 outline-none focus:border-green-500 border-gray-300 text-sm font-normal"%>
+            <%= form.password_field :password_confirmation, placeholder:"請再輸入一次密碼", class:"w-9/12 border py-1 px-2 outline-none focus:border-green-500 border-gray-400 text-sm font-normal rounded-lg"%>
           </div>
         </div>
 
-        <div class="mb-8 px-6">
-          <div class="bg-gray-100 flex">
-            <%=form.label :password_confirmation, "確認密碼", class:"w-3/12 m-2.5 pl-[0.9em] text-gray-700 text-sm font-medium"%><br>
-            <%= form.password_field :password_confirmation, placeholder:"若無需修改留空即可", class:"w-9/12 border py-1 px-2 outline-none focus:border-green-500 border-gray-300 text-sm font-normal"%>
-          </div>
-        </div>
-      <% end %>
-
-      <div class="mb-8 px-6">
-        <div class=" flex items-center bg-gray-100">
-          <%= form.label :address, "地址", class:"w-3/12 m-2.5 pl-[0.9em] text-gray-700 text-sm font-medium"%><br>
-          <div class=w-9/12>
-            <div data-controller="twcity" role="tw-city-selector" data-has-zipcode class="w-full m-1 flex rounded-lg text-gray-700 font-medium">
+        <div class="mb-6 px-6">
+          <div class=" flex items-center bg-gray-100 rounded-lg">
+            <%= form.label :address, "地址", class:"w-4/12 md:w-4/12 p-2.5 pl-6 text-gray-700 text-sm font-medium"%><br>
+            <div class=w-10/12>
+              <div data-controller="twcity" role="tw-city-selector" data-has-zipcode class="w-full m-1 flex grow shrink-0 rounded-lg text-gray-700 font-medium">
+              </div>
+              <%= form.text_field :address, placeholder:"請輸入您的地址", class:"w-full border py-1 px-2 outline-none focus:border-green-500 border-gray-400 text-sm font-normal rounded-lg"%>
             </div>
-            <%= form.text_field :address, placeholder:"請輸入您的地址", class:"w-full box-border border py-1 px-2 outline-none focus:border-green-500 border-gray-300 text-sm font-normal"%>
           </div>
         </div>
+
+        <% if not current_user %>
+          <div class="actions my-5 pb-5 px-1">
+            <%= form.submit "註冊", class:"w-11/12 h-11 flex justify-center items-center m-auto bg-blue-600 text-white hover:bg-blue-700 cursor-pointer rounded-lg"%>
+          </div>
+        <% else %>
+          <div class="actions my-5 pb-5 px-1">
+            <%= form.submit "更新", class:"w-11/12 h-11 flex justify-center items-center m-auto bg-blue-600 text-white hover:bg-blue-700 cursor-pointer rounded-lg"%>
+          </div>
+        <% end %>
       </div>
-
-      <% if not current_user %>
-        <div class="actions my-5 pb-10 px-1">
-          <%= form.submit "註冊", class:"w-11/12 h-11 flex justify-center items-center m-auto bg-blue-600 text-white hover:bg-blue-700 cursor-pointer"%>
-        </div>
-      <% else %>
-        <div class="actions my-5 pb-10 px-1">
-          <%= form.submit "更新", class:"w-11/12 h-11 flex justify-center items-center m-auto bg-blue-600 text-white hover:bg-blue-700 cursor-pointer"%>
-        </div>
-      <% end %>
-
     </div>
 <% end %>


### PR DESCRIPTION
## 更新登入及註冊頁面樣式
###  切圓角及陰影 和 調整padding跟顏色、刪除第三方登入github＆FB
<img width="496" alt="截圖 2022-06-06 下午4 28 38" src="https://user-images.githubusercontent.com/96513629/172125310-d86a41af-7bc8-4b9d-a9ac-6ae0e57b93c0.png">
<img width="1440" alt="截圖 2022-06-06 下午4 28 46" src="https://user-images.githubusercontent.com/96513629/172125285-638d1859-8b9b-4239-be25-77676cf42d17.png">
<img width="502" alt="截圖 2022-06-06 下午4 28 59" src="https://user-images.githubusercontent.com/96513629/172125313-c69f0451-7eb7-40db-ab00-eacd926a9bf3.png"> 
<img width="1431" alt="截圖 2022-06-06 下午4 28 52" src="https://user-images.githubusercontent.com/96513629/172125319-b1fb8d5a-4228-4954-ae91-69f8e450e898.png">


