### PR TITLE
issue/156

### DIFF
--- a/app/javascript/controllers/index.js
+++ b/app/javascript/controllers/index.js
@@ -7,4 +7,4 @@ const application = Application.start();
 const context = require.context("controllers", true, /_controller\.js$/);
 application.load(definitionsFromContext(context));
 application.register("autocomplete", Autocomplete);
-application.register('flash', Notification);
+application.register('flash_animation', Notification);

--- a/app/views/shared/_flash.html.erb
+++ b/app/views/shared/_flash.html.erb
@@ -1,7 +1,7 @@
 <% flash.each do |type, message| %>
   <% if current_user && current_page?(root_url) %>
-    <div data-controller="flash" class="flash flash-<%= type %> w-full absolute top-20 transition transform duration-1000 hidden"
-    data-flash-delay-value="3000"
+    <div data-controller="flash flash_animation" class="flash flash-<%= type %> w-full absolute top-20 transition transform duration-1000 hidden"
+    data-flash_animation-delay-value="2000"
     data-transition-enter-from="opacity-0 translate-y-0"
     data-transition-enter-to="opacity-100 translate-y-0"
     data-transition-leave-from="opacity-100 translate-y-0"
@@ -10,8 +10,8 @@
       <button id="flashCloseBtn" data-action="click->flash#close">X</button>
     </div>
   <% else %>
-    <div data-controller="flash" class="flash flash-<%= type %> transition transform duration-1000 hidden"
-    data-flash-delay-value="3000"
+    <div data-controller="flash flash_animation" class="flash flash-<%= type %> transition transform duration-1000 hidden"
+    data-flash_animation-delay-value="2000"
     data-transition-enter-from="opacity-0 translate-y-0"
     data-transition-enter-to="opacity-100 translate-y-0"
     data-transition-leave-from="opacity-100 translate-y-0"


### PR DESCRIPTION
#156 
1. 修正 stimulus controller 名稱和原本 flash stimulus 名稱相同衝突問題，將 stimulus-notification register 名稱由 flash 修正為 flash-animation，修正後測試 remove button 功能和動畫可正常運作。